### PR TITLE
Sec4: Refactoring for cleaner code

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,9 +4,10 @@
   "description": "Server side rendering project",
   "main": "index.js",
   "scripts": {
+    "dev": "npm-run-all --parallel dev:*",
     "dev:server": "nodemon --watch build --exec \"node build/bundle.js\"",
-    "dev:build:server": "webpack --config webpack.server.js --watch",
-    "dev:build:client": "webpack --config webpack.client.js --watch"
+    "dev:build-server": "webpack --config webpack.server.js --watch",
+    "dev:build-client": "webpack --config webpack.client.js --watch"
   },
   "author": "",
   "license": "ISC",

--- a/server/src/helpers/renderer.js
+++ b/server/src/helpers/renderer.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import Home from '../client/components/Home';
+
+export default () => {
+  const content = renderToString(<Home />);
+
+  return `
+    <html>
+      <head></head>
+      <body>
+        <div id="root">${content}</div>
+        <script src="bundle.js"></script>
+      </body>
+    </html>
+  `;
+};

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,24 +1,12 @@
 import express from 'express';
-import React from 'react';
-import { renderToString } from 'react-dom/server';
-import Home from './client/components/Home';
+import renderer from './helpers/renderer';
 
 const app = express();
 
 app.use(express.static('public'));
 
 app.get('/', (req, res) => {
-  const content = renderToString(<Home />);
-  const html = `
-    <html>
-      <head></head>
-      <body>
-        <div id="root">${content}</div>
-        <script src="bundle.js"></script>
-      </body>
-    </html>
-  `;
-  res.send(html);
+  res.send(renderer());
 });
 
 app.listen(3000, () => {

--- a/server/webpack.base.js
+++ b/server/webpack.base.js
@@ -1,0 +1,18 @@
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.js?$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        options: {
+          presets: [
+            'react',
+            'stage-0',
+            ['env', { targets: { browsers: ['last 2 versions'] } }]
+          ]
+        }
+      }
+    ]
+  }
+};

--- a/server/webpack.client.js
+++ b/server/webpack.client.js
@@ -1,25 +1,13 @@
 const path = require('path');
+const merge = require('webpack-merge');
+const baseConfig = require('./webpack.base.js');
 
-module.exports = {
+const config = {
   entry: './src/client/client.js',
   output: {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'public'),
   },
-  module: {
-    rules: [
-      {
-        test: /\.js?$/,
-        loader: 'babel-loader',
-        exclude: /node_modules/,
-        options: {
-          presets: [
-            'react',
-            'stage-0',
-            ['env', { targets: { browsers: ['last 2 versions'] } }]
-          ]
-        }
-      }
-    ]
-  }
 }
+
+module.exports = merge(baseConfig, config);

--- a/server/webpack.server.js
+++ b/server/webpack.server.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const merge = require('webpack-merge');
 const baseConfig = require('./webpack.base.js');
+const webpackNodeExternals = require('webpack-node-externals');
 
 const config = {
   target: 'node',
@@ -9,6 +10,7 @@ const config = {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'build'),
   },
+  externals: [webpackNodeExternals()],
 }
 
 module.exports = merge(baseConfig, config);

--- a/server/webpack.server.js
+++ b/server/webpack.server.js
@@ -1,26 +1,14 @@
 const path = require('path');
+const merge = require('webpack-merge');
+const baseConfig = require('./webpack.base.js');
 
-module.exports = {
+const config = {
   target: 'node',
   entry: './src/index.js',
   output: {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'build'),
   },
-  module: {
-    rules: [
-      {
-        test: /\.js?$/,
-        loader: 'babel-loader',
-        exclude: /node_modules/,
-        options: {
-          presets: [
-            'react',
-            'stage-0',
-            ['env', { targets: { browsers: ['last 2 versions'] } }]
-          ]
-        }
-      }
-    ]
-  }
 }
+
+module.exports = merge(baseConfig, config);


### PR DESCRIPTION
## WHAT
- webpack の server と client の共通の設定を切り出して、webpack-merge で merge するようにする
- `npm dev:server` `npm dev:build:server` `npm dev:build:client` と３つのコマンドを叩いていたのを npm-run-all を使って1つのコマンドでできるようにする
- node_modules 以下にいる module は server の bundle.js には bundle しないようにする（ファイルサイズ削減）
- HTML を render する部分を index.js から別ファイルに切り出す