### PR TITLE
Sec5: Adding navigation

### DIFF
--- a/server/src/client/Routes.js
+++ b/server/src/client/Routes.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import Home from './components/Home';
+
+export default () => {
+  return(
+    <div>
+      <Route exact path="/" component={Home} />
+    </div>
+  );
+};

--- a/server/src/client/client.js
+++ b/server/src/client/client.js
@@ -1,5 +1,11 @@
 import React from 'react';
 import ReactDom from 'react-dom';
-import Home from './components/Home';
+import { BrowserRouter } from 'react-router-dom';
+import Routes from './Routes';
 
-ReactDom.hydrate(<Home />, document.getElementById('root'));
+ReactDom.hydrate(
+  <BrowserRouter>
+    <Routes />
+  </BrowserRouter>,
+  document.getElementById('root')
+);

--- a/server/src/helpers/renderer.js
+++ b/server/src/helpers/renderer.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import { renderToString } from 'react-dom/server';
-import Home from '../client/components/Home';
+import { StaticRouter } from 'react-router-dom';
+import Routes from '../client/Routes';
 
-export default () => {
-  const content = renderToString(<Home />);
+export default (req) => {
+  const content = renderToString(
+    <StaticRouter location={req.path} context={{}}>
+      <Routes />
+    </StaticRouter>
+  );
 
   return `
     <html>

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -6,7 +6,7 @@ const app = express();
 app.use(express.static('public'));
 
 app.get('/', (req, res) => {
-  res.send(renderer());
+  res.send(renderer(req));
 });
 
 app.listen(3000, () => {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -5,7 +5,7 @@ const app = express();
 
 app.use(express.static('public'));
 
-app.get('/', (req, res) => {
+app.get('*', (req, res) => {
   res.send(renderer(req));
 });
 


### PR DESCRIPTION
## WHAT
- react-router を使って react 層の routing を定義 (Routes.js)
- client 側では `BrowserRouter`, server 側では `StaticRouter` を使って、上の routes をセットアップ
  - `BrowserRouter` はブラウザのアドレスバーから path を取得する
  - `StaticRouter` は `location` prop で明示的に path を渡してあげる必要がある
- express 層の routing ではすべての path を受け付けて、react 層に流す
  