### PR TITLE
Sec7: Server-side data loading

### DIFF
--- a/server/src/client/Routes.js
+++ b/server/src/client/Routes.js
@@ -1,13 +1,15 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
 import Home from './components/Home';
 import UsersList from './components/UsersList';
 
-export default () => {
-  return(
-    <div>
-      <Route exact path="/" component={Home} />
-      <Route exact path="/users" component={UsersList} />
-    </div>
-  );
-};
+export default [
+  {
+    path: "/",
+    component: Home,
+    exact: true,
+  },
+  {
+    path: "/users",
+    component: UsersList,
+  },
+];

--- a/server/src/client/Routes.js
+++ b/server/src/client/Routes.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Home from './components/Home';
-import UsersList from './components/UsersList';
+import UsersList, { loadData } from './components/UsersList';
 
 export default [
   {
@@ -9,6 +9,7 @@ export default [
     exact: true,
   },
   {
+    loadData,
     path: "/users",
     component: UsersList,
   },

--- a/server/src/client/client.js
+++ b/server/src/client/client.js
@@ -5,7 +5,8 @@ import { BrowserRouter } from 'react-router-dom';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
-import Routes from './Routes';
+import { renderRoutes } from 'react-router-config';
+import routes from './routes';
 import reducers from './reducers';
 
 const store = createStore(reducers, {}, applyMiddleware(thunk));
@@ -13,7 +14,7 @@ const store = createStore(reducers, {}, applyMiddleware(thunk));
 ReactDom.hydrate(
   <Provider store={store}>
     <BrowserRouter>
-      <Routes />
+      {renderRoutes(routes)}
     </BrowserRouter>
   </Provider>,
   document.getElementById('root')

--- a/server/src/client/components/UsersList.js
+++ b/server/src/client/components/UsersList.js
@@ -27,4 +27,9 @@ function mapStateToProps(state) {
   return { users: state.users };
 }
 
+function loadData(store) {
+  return store.dispatch(fetchUsers());
+}
+
+export { loadData };
 export default connect(mapStateToProps, { fetchUsers })(UsersList);

--- a/server/src/helpers/renderer.js
+++ b/server/src/helpers/renderer.js
@@ -2,13 +2,14 @@ import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { StaticRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import Routes from '../client/Routes';
+import { renderRoutes } from 'react-router-config';
+import routes from '../client/routes';
 
 export default (req, store) => {
   const content = renderToString(
     <Provider store={store}>
       <StaticRouter location={req.path} context={{}}>
-        <Routes />
+        {renderRoutes(routes)}
       </StaticRouter>
     </Provider>
   );

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -2,6 +2,8 @@ import 'babel-polyfill';
 import express from 'express';
 import renderer from './helpers/renderer';
 import createStore from './helpers/createStore';
+import { matchRoutes } from 'react-router-config';
+import routes from './client/routes';
 
 const app = express();
 
@@ -9,7 +11,12 @@ app.use(express.static('public'));
 
 app.get('*', (req, res) => {
   const store = createStore();
-  res.send(renderer(req, store));
+  const promises = matchRoutes(routes, req.path).map(({ route }) => {
+    return route.loadData ? route.loadData(store) : null;
+  });
+  Promise.all(promises).then(() => {
+    res.send(renderer(req, store));
+  });
 });
 
 app.listen(3000, () => {


### PR DESCRIPTION
## WHT
- server 側で初期データをロードしてから render することで真に server-side rendering を行う

## WHAT
これを実現するために [react-router-config](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-config) を使う

- 各 component に各自が必要なデータを取得するための action を dispatch する `loadData()` を用意する
- routes に各 component に対応する `loadData()` の情報を持たせる
- index.js において `matchRoutes()` で path から render すべき component を取得し、それらの component の `loadData()` をすべて呼んだ上で、それらすべてが resolve したら render するようにする