### PR TITLE
Sec9: Authentication in a server-side rendering world

### DIFF
--- a/server/src/client/App.js
+++ b/server/src/client/App.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import { renderRoutes } from 'react-router-config';
+import Header from './components/Header';
 
 const App = ({ route }) => {
   return (
     <div>
-      <h1>I'm a header</h1>
+      <Header />
       {renderRoutes(route.routes)}
     </div>
   );

--- a/server/src/client/App.js
+++ b/server/src/client/App.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { renderRoutes } from 'react-router-config';
+
+const App = ({ route }) => {
+  return (
+    <div>
+      <h1>I'm a header</h1>
+      {renderRoutes(route.routes)}
+    </div>
+  );
+};
+
+export default {
+  component: App,
+};

--- a/server/src/client/App.js
+++ b/server/src/client/App.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { renderRoutes } from 'react-router-config';
 import Header from './components/Header';
+import { fetchCurrentUser } from './actions';
 
 const App = ({ route }) => {
   return (
@@ -13,4 +14,5 @@ const App = ({ route }) => {
 
 export default {
   component: App,
+  loadData: ({ dispatch }) => dispatch(fetchCurrentUser()),
 };

--- a/server/src/client/actions/index.js
+++ b/server/src/client/actions/index.js
@@ -1,8 +1,6 @@
-import axios from 'axios';
-
 export const FETCH_USERS = 'fetch_users';
-export const fetchUsers = () => async dispatch => {
-  const res = await axios.get('https://react-ssr-api.herokuapp.com/users');
+export const fetchUsers = () => async (dispatch, getState, api) => {
+  const res = await api.get('/users');
 
   dispatch({
     type: FETCH_USERS,

--- a/server/src/client/actions/index.js
+++ b/server/src/client/actions/index.js
@@ -7,3 +7,13 @@ export const fetchUsers = () => async (dispatch, getState, api) => {
     payload: res,
   });
 };
+
+export const FETCH_CURRENT_USER = 'fetch_current_user';
+export const fetchCurrentUser = () => async (dispatch, getState, api) => {
+  const res = await api.get('/current_user');
+
+  dispatch ({
+    type: FETCH_CURRENT_USER,
+    payload: res,
+  })
+};

--- a/server/src/client/client.js
+++ b/server/src/client/client.js
@@ -6,10 +6,19 @@ import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { renderRoutes } from 'react-router-config';
+import axios from 'axios';
 import routes from './routes';
 import reducers from './reducers';
 
-const store = createStore(reducers, window.INITIAL_STATE, applyMiddleware(thunk));
+const axiosInstance = axios.create({
+  baseURL: "/api",
+});
+
+const store = createStore(
+  reducers,
+  window.INITIAL_STATE,
+  applyMiddleware(thunk.withExtraArgument(axiosInstance))
+);
 
 ReactDom.hydrate(
   <Provider store={store}>

--- a/server/src/client/components/Header.js
+++ b/server/src/client/components/Header.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default () => {
+  return (
+    <div>
+      <Link to="/">React SSR</Link>
+    </div>
+  );
+};

--- a/server/src/client/components/Header.js
+++ b/server/src/client/components/Header.js
@@ -1,10 +1,28 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
 
-export default () => {
+const Header = ({ auth }) => {
+  const authButton = auth ? (
+    <a href="/api/logout">Logout</a>
+  ) : (
+    <a href="/api/auth/google">Login</a>
+  );
+
   return (
     <div>
       <Link to="/">React SSR</Link>
+      <div>
+        <Link to="/users">Users</Link>
+        <Link to="/admins">Admins</Link>
+        {authButton}
+      </div>
     </div>
   );
 };
+
+function mapStateToProps({ auth }) {
+  return { auth };
+}
+
+export default connect(mapStateToProps)(Header);

--- a/server/src/client/components/Header.js
+++ b/server/src/client/components/Header.js
@@ -10,14 +10,16 @@ const Header = ({ auth }) => {
   );
 
   return (
-    <div>
-      <Link to="/">React SSR</Link>
-      <div>
-        <Link to="/users">Users</Link>
-        <Link to="/admins">Admins</Link>
-        {authButton}
+    <nav>
+      <div className="nav-wrapper">
+        <Link to="/" className="brand-logo">React SSR</Link>
+        <ul className="right">
+          <li><Link to="/users">Users</Link></li>
+          <li><Link to="/admins">Admins</Link></li>
+          <li>{authButton}</li>
+        </ul>
       </div>
-    </div>
+    </nav>
   );
 };
 

--- a/server/src/client/pages/HomePage.js
+++ b/server/src/client/pages/HomePage.js
@@ -2,9 +2,9 @@ import React from 'react';
 
 const Home = () => {
   return (
-    <div>
-      <div>I'm the Home component!</div>
-      <button onClick={() => console.log('Hi there!')}>Press me!</button>
+    <div className="center-align" style={{ marginTop: "200px" }}>
+      <h3>Welcome</h3>
+      <p>Check out these awesome features</p>
     </div>
   );
 };

--- a/server/src/client/reducers/authReducer.js
+++ b/server/src/client/reducers/authReducer.js
@@ -1,0 +1,10 @@
+import { FETCH_CURRENT_USER } from '../actions';
+
+export default (state = null, action) => {
+  switch (action.type) {
+    case (FETCH_CURRENT_USER):
+      return action.payload.data || false;
+    default:
+      return state;
+  }
+}

--- a/server/src/client/reducers/index.js
+++ b/server/src/client/reducers/index.js
@@ -1,6 +1,8 @@
 import { combineReducers } from 'redux';
 import usersReducer from './usersReducer';
+import authReducer from './authReducer';
 
 export default combineReducers({
   users: usersReducer,
+  auth: authReducer,
 });

--- a/server/src/client/routes.js
+++ b/server/src/client/routes.js
@@ -1,15 +1,22 @@
 import React from 'react';
+import App from './App';
 import HomePage from './pages/HomePage';
 import UsersListPage from './pages/UsersListPage';
 
 export default [
   {
-    ...HomePage,
-    path: "/",
-    exact: true,
-  },
-  {
-    ...UsersListPage,
-    path: "/users",
-  },
+    ...App,
+    routes: [
+      {
+        ...HomePage,
+        path: "/",
+        exact: true,
+      },
+      {
+        ...UsersListPage,
+        path: "/users",
+      },
+    ]
+  }
+
 ];

--- a/server/src/helpers/createStore.js
+++ b/server/src/helpers/createStore.js
@@ -1,8 +1,19 @@
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
+import axios from 'axios';
 import reducers from '../client/reducers';
 
-export default () => {
-  const store = createStore(reducers, {}, applyMiddleware(thunk));
+export default (req) => {
+  const axoisInstance = axios.create({
+    baseURL: "http://react-ssr-api.herokuapp.com",
+    headers: { cookie: req.get('cookie') || "" },
+  })
+
+  const store = createStore(
+    reducers,
+    {},
+    applyMiddleware(thunk.withExtraArgument(axoisInstance))
+  );
+
   return store;
 };

--- a/server/src/helpers/renderer.js
+++ b/server/src/helpers/renderer.js
@@ -17,7 +17,9 @@ export default (req, store) => {
 
   return `
     <html>
-      <head></head>
+      <head>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/css/materialize.min.css">
+      </head>
       <body>
         <div id="root">${content}</div>
         <script>

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -18,7 +18,7 @@ app.use('/api', proxy('https://react-ssr-api.herokuapp.com', {
 }));
 
 app.get('*', (req, res) => {
-  const store = createStore();
+  const store = createStore(req);
   const promises = matchRoutes(routes, req.path).map(({ route }) => {
     return route.loadData ? route.loadData(store) : null;
   });

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -10,7 +10,7 @@ const app = express();
 
 app.use(express.static('public'));
 
-app.use('/api', proxy('https://react-ssr-api.herokuapp.com', {
+app.use('/api', proxy('http://react-ssr-api.herokuapp.com', {
   proxyReqOptDecorator(opts) {
     opts.headers['x-forwarded-host'] = 'localhost:3000';
     return opts;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,13 +1,21 @@
 import 'babel-polyfill';
 import express from 'express';
+import proxy from 'express-http-proxy';
+import { matchRoutes } from 'react-router-config';
 import renderer from './helpers/renderer';
 import createStore from './helpers/createStore';
-import { matchRoutes } from 'react-router-config';
 import routes from './client/routes';
 
 const app = express();
 
 app.use(express.static('public'));
+
+app.use('/api', proxy('https://react-ssr-api.herokuapp.com', {
+  proxyReqOptDecorator(opts) {
+    opts.headers['x-forwarded-host'] = 'localhost:3000';
+    return opts;
+  }
+}));
 
 app.get('*', (req, res) => {
   const store = createStore();


### PR DESCRIPTION
## WHY
- authentication を導入し、ログインしているかどうかで表示内容を変えられるようにする

## HOW
- API server での認証にはクライアントのブラウザーから自動的に付加される cookie が必要
- SSR する際にも API に問い合わせるためにその cookie が必要なので、ブラウザが cookie をつける対象は API server のドメインではなく render server のドメインにする必要がある
- client 側から follow-up request で API に問い合わせるときも、直接 API に問い合わせずに、render server で proxy する（ことで cookie が付与される）
- API への問い合わせが server 側からなのか client 側からなのかで問い合わせる URL が変わる
  - server 側からは http://react-ssr-api.herokuapp.com/users
  - client 側からは localhost:3000/api/users

![image](https://user-images.githubusercontent.com/7016832/34595044-0d3336fe-f218-11e7-953a-91b929536dd1.png)

### API のエンドポイント一覧
![image](https://user-images.githubusercontent.com/7016832/34595721-73e5851e-f21d-11e7-93eb-699d2b6b64bd.png)

## WHAT

- API への問い合わせが server 側からなのか client 側からなのかで問い合わせる URL を切り変えるために axios のインスタンスを server 側と client 側で二種類用意する
  - server 側では受け取ったパスを `http://react-ssr-api.herokuapp.com/` に、client 側では自ホストの `/api/` 以下に投げるようにする
  - また server 側では、ブラウザーから受け取った cookie をそのまま API server へのリクエストに付けるようにする
- これらの異なる axios インスタンスが使えるように、redux-thunk の [`withExtraArgument()`](https://github.com/gaearon/redux-thunk#injecting-a-custom-argument) で axios インスタンスを渡し、action creator 内で使えるようにする
- すべてのページに共通のヘッダーを置くために App component を用意し、これまでの routing は App component 内で [`renderRoutes()`](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-config#renderroutesroutes-extraprops---switchprops--) することで階層化する
- App component の `loadData()` で action の `fetchCurrentUser()` を叩き、API からログイン状態を取得する

  
  