### PR TITLE
Sec10: Error handling

### DIFF
--- a/server/src/client/actions/index.js
+++ b/server/src/client/actions/index.js
@@ -17,3 +17,13 @@ export const fetchCurrentUser = () => async (dispatch, getState, api) => {
     payload: res,
   })
 };
+
+export const FETCH_ADMINS = 'fetch_admins';
+export const fetchAdmins = () => async (dispatch, getState, api) => {
+  const res = await api.get('/admins');
+
+  dispatch({
+    type: FETCH_ADMINS,
+    payload: res,
+  });
+};

--- a/server/src/client/components/hocs/requireAuth.js
+++ b/server/src/client/components/hocs/requireAuth.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Redirect } from 'react-router-dom';
+
+export default ChildComponent => {
+  class RequireAuth extends Component {
+    render() {
+      switch (this.props.auth) {
+        case null:
+          return <div>Loading...</div>;
+        case false:
+          return <Redirect to="/" />;
+        default:
+          return <ChildComponent {...this.props} />;
+      }
+    }
+  }
+
+  function mapStateToProps({ auth }) {
+    return { auth };
+  }
+
+  return connect(mapStateToProps)(RequireAuth);
+};

--- a/server/src/client/pages/AdminsListPage.js
+++ b/server/src/client/pages/AdminsListPage.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { fetchAdmins } from '../actions';
+import requireAuth from '../components/hocs/requireAuth';
 
 class AdminsListPage extends Component {
   componentDidMount() {
@@ -28,6 +29,6 @@ function mapStateToProps({ admins }) {
 }
 
 export default {
-  component: connect(mapStateToProps, { fetchAdmins })(AdminsListPage),
+  component: connect(mapStateToProps, { fetchAdmins })(requireAuth(AdminsListPage)),
   loadData: (store) => store.dispatch(fetchAdmins()),
 };

--- a/server/src/client/pages/AdminsListPage.js
+++ b/server/src/client/pages/AdminsListPage.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { fetchAdmins } from '../actions';
+
+class AdminsListPage extends Component {
+  componentDidMount() {
+    this.props.fetchAdmins();
+  }
+
+  renderAdmins() {
+    return this.props.admins.map(admin => {
+      return <li key={admin.id}>{admin.name}</li>;
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <h3>Protected list of admins</h3>
+        <ul>{this.renderAdmins()}</ul>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps({ admins }) {
+  return { admins };
+}
+
+export default {
+  component: connect(mapStateToProps, { fetchAdmins })(AdminsListPage),
+  loadData: (store) => store.dispatch(fetchAdmins()),
+};

--- a/server/src/client/pages/NotFoundPage.js
+++ b/server/src/client/pages/NotFoundPage.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const NotFoundPage = () => {
+  return <h1>Oops, route not found!</h1>;
+};
+
+export default {
+  component: NotFoundPage,
+};

--- a/server/src/client/pages/NotFoundPage.js
+++ b/server/src/client/pages/NotFoundPage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
-const NotFoundPage = () => {
+const NotFoundPage = ({ staticContext = {} }) => {
+  staticContext.notFound = true;
   return <h1>Oops, route not found!</h1>;
 };
 

--- a/server/src/client/reducers/adminsReducer.js
+++ b/server/src/client/reducers/adminsReducer.js
@@ -1,0 +1,10 @@
+import { FETCH_ADMINS } from '../actions';
+
+export default (state = [], action) => {
+  switch (action.type) {
+    case (FETCH_ADMINS):
+      return action.payload.data;
+    default:
+      return state;
+  }
+};

--- a/server/src/client/reducers/index.js
+++ b/server/src/client/reducers/index.js
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux';
 import usersReducer from './usersReducer';
 import authReducer from './authReducer';
+import adminsReducer from './adminsReducer';
 
 export default combineReducers({
   users: usersReducer,
   auth: authReducer,
+  admins: adminsReducer,
 });

--- a/server/src/client/routes.js
+++ b/server/src/client/routes.js
@@ -2,6 +2,7 @@ import React from 'react';
 import App from './App';
 import HomePage from './pages/HomePage';
 import UsersListPage from './pages/UsersListPage';
+import NotFoundPage from './pages/NotFoundPage';
 
 export default [
   {
@@ -15,6 +16,9 @@ export default [
       {
         ...UsersListPage,
         path: "/users",
+      },
+      {
+        ...NotFoundPage,
       },
     ]
   }

--- a/server/src/client/routes.js
+++ b/server/src/client/routes.js
@@ -3,6 +3,7 @@ import App from './App';
 import HomePage from './pages/HomePage';
 import UsersListPage from './pages/UsersListPage';
 import NotFoundPage from './pages/NotFoundPage';
+import AdminsListPage from './pages/AdminsListPage';
 
 export default [
   {
@@ -16,6 +17,10 @@ export default [
       {
         ...UsersListPage,
         path: "/users",
+      },
+      {
+        ...AdminsListPage,
+        path: "/admins",
       },
       {
         ...NotFoundPage,

--- a/server/src/helpers/renderer.js
+++ b/server/src/helpers/renderer.js
@@ -6,10 +6,10 @@ import { renderRoutes } from 'react-router-config';
 import routes from '../client/routes';
 import serialize from 'serialize-javascript';
 
-export default (req, store) => {
+export default (req, store, context) => {
   const content = renderToString(
     <Provider store={store}>
-      <StaticRouter location={req.path} context={{}}>
+      <StaticRouter location={req.path} context={context}>
         {renderRoutes(routes)}
       </StaticRouter>
     </Provider>

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -19,9 +19,17 @@ app.use('/api', proxy('http://react-ssr-api.herokuapp.com', {
 
 app.get('*', (req, res) => {
   const store = createStore(req);
+
   const promises = matchRoutes(routes, req.path).map(({ route }) => {
     return route.loadData ? route.loadData(store) : null;
+  }).map(promise => {
+    if (promise) {
+      return new Promise((resolve, reject) => {
+        promise.then(resolve).catch(resolve);
+      })
+    }
   });
+
   Promise.all(promises).then(() => {
     const context = {};
     const content = renderer(req, store, context)

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -23,7 +23,12 @@ app.get('*', (req, res) => {
     return route.loadData ? route.loadData(store) : null;
   });
   Promise.all(promises).then(() => {
-    res.send(renderer(req, store));
+    const context = {};
+    const content = renderer(req, store, context)
+    if (context.notFound) {
+      res.status(404);
+    }
+    res.send(content);
   });
 });
 

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -32,10 +32,15 @@ app.get('*', (req, res) => {
 
   Promise.all(promises).then(() => {
     const context = {};
-    const content = renderer(req, store, context)
+    const content = renderer(req, store, context);
+
+    if (context.url) {
+      return res.redirect(302, context.url);
+    }
     if (context.notFound) {
       res.status(404);
     }
+
     res.send(content);
   });
 });


### PR DESCRIPTION
## WHAT
- routing に他にマッチするものがないときに Not found ページを表示し、SSR 時には response status を 404 にセットする
- auth が必要なページを render する際に component を wrap して使える higher order component として `requireAuth()` を作る
  - ログイン済みなら受け取った child component をそのまま render し、未ログインなら root ページに redirect する
- `loadData()` が reject されても hang せずに render できるように、`loadData()` が返す promise を wrap して、常に resolve する promise を作り、それを `Promise.all()` に渡す
  
  
  